### PR TITLE
NotifyPropertyChangedBase 1.1.0

### DIFF
--- a/AfterBuild.ps1
+++ b/AfterBuild.ps1
@@ -22,7 +22,7 @@ foreach ($projectFolder in $projectFolders)
 		continue;
 	}
 
-	$zipFileName    = "$projectFolder$nugetVersion.zip"
+	$zipFileName    = "$projectFolder.$nugetVersion.zip"
 	7z a $zipFileName "$releaseFolder\*"
 	
 	Push-AppveyorArtifact $zipFileName

--- a/AfterBuild.ps1
+++ b/AfterBuild.ps1
@@ -1,20 +1,3 @@
-$projectFolders = Get-ChildItem -Directory -Filter "NotifyPropertyChangedBase*"
-
-foreach ($projectFolder in $projectFolders)
-{
-	$releaseFolder = Join-Path $projectFolder.FullName "\bin\Release"
-
-	if (!(Test-Path $releaseFolder))
-	{
-		continue;
-	}
-
-	$zipFileName    = "$projectFolder.zip"
-	7z a $zipFileName "$releaseFolder\*"
-	
-	Push-AppveyorArtifact $zipFileName
-}
-
 $nugetVersion = $env:APPVEYOR_BUILD_VERSION
 
 if ($env:APPVEYOR_REPO_BRANCH -eq "master")
@@ -26,6 +9,23 @@ if ($env:APPVEYOR_REPO_BRANCH -eq "master")
 	Write-Host $message
 
 	$nugetVersion = $newVersion
+}
+
+$projectFolders = Get-ChildItem -Directory -Filter "NotifyPropertyChangedBase*"
+
+foreach ($projectFolder in $projectFolders)
+{
+	$releaseFolder = Join-Path $projectFolder.FullName "\bin\Release"
+
+	if (!(Test-Path $releaseFolder))
+	{
+		continue;
+	}
+
+	$zipFileName    = "$projectFolder$nugetVersion.zip"
+	7z a $zipFileName "$releaseFolder\*"
+	
+	Push-AppveyorArtifact $zipFileName
 }
 
 NuGet pack -Version $nugetVersion

--- a/NotifyPropertyChangedBase.nuspec
+++ b/NotifyPropertyChangedBase.nuspec
@@ -12,7 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Provides an easy to use base class NotifyPropertyChanged that helps you implement the INotifyPropertyChanged interface.</description>
     <copyright>© 2017 Marian Dolinský</copyright>
-    <tags>C# Helper Helpers Binding Bindings</tags>
+    <tags>C# Helper Helpers Binding Bindings MVVM</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5" />
       <group targetFramework=".NETFramework4.0" />

--- a/NotifyPropertyChangedBase/NotifyPropertyChanged.cs
+++ b/NotifyPropertyChangedBase/NotifyPropertyChanged.cs
@@ -20,9 +20,24 @@ namespace NotifyPropertyChangedBase
         private readonly Dictionary<string, PropertyData> backingStore = new Dictionary<string, PropertyData>();
 
         /// <summary>
+        /// Gets or sets the value indicating whether the <see cref="PropertyChanged"/> event should be invoked
+        /// from the <see cref="SetValue(object, string)"/> and <see cref="ForceSetValue(object, string)"/> methods
+        /// when property changes. The default value is <c>true</c>.
+        /// </summary>
+        protected bool IsPropertyChangedEventInvokingEnabled { get; set; }
+
+        /// <summary>
         /// Implementation of the <see cref="INotifyPropertyChanged.PropertyChanged"/> event. Occurs when a property value changes.
         /// </summary>
         public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotifyPropertyChanged"/> class.
+        /// </summary>
+        protected NotifyPropertyChanged()
+        {
+            IsPropertyChangedEventInvokingEnabled = true;
+        }
 
         /// <summary>
         /// Registers a new property for the actual instance of <see cref="NotifyPropertyChanged"/>.
@@ -203,7 +218,11 @@ namespace NotifyPropertyChangedBase
                     propertyData.Value  = value;
 
                     propertyData.PropertyChangedCallback?.Invoke(this, new PropertyChangedCallbackArgs(oldValue, value));
-                    OnPropertyChanged(propertyName);
+
+                    if (IsPropertyChangedEventInvokingEnabled)
+                    {
+                        OnPropertyChanged(propertyName);
+                    }
                 }
             }
             catch (Exception exception)

--- a/NotifyPropertyChangedBase/NotifyPropertyChanged.cs
+++ b/NotifyPropertyChangedBase/NotifyPropertyChanged.cs
@@ -20,9 +20,15 @@ namespace NotifyPropertyChangedBase
         private readonly Dictionary<string, PropertyData> backingStore = new Dictionary<string, PropertyData>();
 
         /// <summary>
+        /// Gets or sets the value indicating whether the <see cref="PropertyChangedCallbackHandler"/> specific for each property should be invoked
+        /// from the <see cref="SetValue(object, string)"/> and <see cref="ForceSetValue(object, string)"/> methods
+        /// when a property changes. The default value is <c>true</c>.
+        /// </summary>
+        protected bool IsPropertyChangedCallbackInvokingEnabled { get; set; }
+        /// <summary>
         /// Gets or sets the value indicating whether the <see cref="PropertyChanged"/> event should be invoked
         /// from the <see cref="SetValue(object, string)"/> and <see cref="ForceSetValue(object, string)"/> methods
-        /// when property changes. The default value is <c>true</c>.
+        /// when a property changes. The default value is <c>true</c>.
         /// </summary>
         protected bool IsPropertyChangedEventInvokingEnabled { get; set; }
 
@@ -36,7 +42,8 @@ namespace NotifyPropertyChangedBase
         /// </summary>
         protected NotifyPropertyChanged()
         {
-            IsPropertyChangedEventInvokingEnabled = true;
+            IsPropertyChangedCallbackInvokingEnabled    = true;
+            IsPropertyChangedEventInvokingEnabled       = true;
         }
 
         /// <summary>
@@ -154,7 +161,9 @@ namespace NotifyPropertyChangedBase
         }
 
         /// <summary>
-        /// Sets new value to a registered property even if it is equal and invokes the <see cref="PropertyChanged"/> event.
+        /// Sets new value to a registered property even if it is equal and invokes the <see cref="PropertyChangedCallbackHandler"/> for the property if specified before
+        /// and if the value of <see cref="IsPropertyChangedCallbackInvokingEnabled"/> is <c>true</c> and also invokes the <see cref="PropertyChanged"/> event
+        /// if value of <see cref="IsPropertyChangedEventInvokingEnabled"/> is <c>true</c>.
         /// </summary>
         /// <param name="value">New value for the property.</param>
         /// <param name="propertyName">Name of the property.</param>
@@ -179,7 +188,9 @@ namespace NotifyPropertyChangedBase
         }
 
         /// <summary>
-        /// Sets new value to a registered property if it's not equal and invokes the <see cref="PropertyChanged"/> event.
+        /// Sets a new value to a registered property if it's not equal and invokes the <see cref="PropertyChangedCallbackHandler"/> for the property if specified before
+        /// and if the value of <see cref="IsPropertyChangedCallbackInvokingEnabled"/> is <c>true</c> and also invokes the <see cref="PropertyChanged"/> event
+        /// if value of <see cref="IsPropertyChangedEventInvokingEnabled"/> is <c>true</c>.
         /// </summary>
         /// <param name="value">New value for the property.</param>
         /// <param name="propertyName">Name of the property.</param>
@@ -217,7 +228,10 @@ namespace NotifyPropertyChangedBase
                     object oldValue     = propertyData.Value;
                     propertyData.Value  = value;
 
-                    propertyData.PropertyChangedCallback?.Invoke(this, new PropertyChangedCallbackArgs(oldValue, value));
+                    if (IsPropertyChangedCallbackInvokingEnabled)
+                    {
+                        propertyData.PropertyChangedCallback?.Invoke(this, new PropertyChangedCallbackArgs(oldValue, value));
+                    }
 
                     if (IsPropertyChangedEventInvokingEnabled)
                     {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.1-{branch}{build}
+version: 1.1.0-{branch}{build}
 pull_requests:
   do_not_increment_build_number: true
 branches:
@@ -11,9 +11,9 @@ configuration: Release
 assembly_info:
   patch: true
   file: SharedAssemblyInfo.cs
-  assembly_version: 1.0.1.{build}
-  assembly_file_version: 1.0.1.{build}
-  assembly_informational_version: 1.0.1.{build}
+  assembly_version: 1.1.0.{build}
+  assembly_file_version: 1.1.0.{build}
+  assembly_informational_version: 1.1.0.{build}
 before_build:
 - cmd: nuget restore
 build:


### PR DESCRIPTION
- added an ability to disable invoking the `PropertyChanged` event using the `IsPropertyChangedEventInvokingEnabled` property
- added an ability to disable invoking the `PropertyChangedCallbackHandler` specified for properties using the `IsPropertyChangedCallbackInvokingEnabled` property
- fixed exception that prevented from setting `null` to any property